### PR TITLE
Add email for formspree in config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -207,7 +207,8 @@ googleAnalytics = ""
     # - send a dummy email yourself to confirm your account
     # - click the confirm link in the email from www.formspree.io
     # - you're done. Happy mailing!
-    # formEmail = "example@domain.com"
+
+    formEmail = "jamesfsullivan5@gmail.com"
 
     # Contact Section
     # You can add multiple emails, phone numbers, or addresses


### PR DESCRIPTION
Adds email to formspree to activate contact form